### PR TITLE
Version 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # DocuSign Admin Java Client Changelog
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v1.3.0] - Admin API v2.1-1.3.0 - 2023-08-14
+### Changed
+- Added support for version v2.1-1.3.0 of the DocuSign Admin API.
+- Updated the SDK release version.
+
+New endpoints:
+* `GET /v1/organizations/{organizationId}/assetGroups/accounts` Get asset group accounts for an organization.
+* `POST /v1/organizations/{organizationId}/assetGroups/accountClone` Clone an existing DocuSign account.
+* `GET /v1/organizations/{organizationId}/assetGroups/accountClones` Gets all asset group account clones for an organization.
+* `GET /v1/organizations/{organizationId}/assetGroups/{assetGroupId}/accountClones/{assetGroupWorkId}` Gets information about a single cloned account.
 ## [v1.2.0] - Admin API v2.1-1.2.0 - 2023-05-10
 ### Changed
 - Added support for version v2.1-1.2.0 of the DocuSign Admin API.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>docusign-admin-java</artifactId>
     <packaging>jar</packaging>
     <name>docusign-admin-java</name>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <url>https://developers.docusign.com</url>
     <description>The DocuSign Admin API enables you to automate user management with your existing systems while ensuring governance and compliance.</description>
 
@@ -170,7 +170,7 @@
                 </executions>
                 <configuration>
                 </configuration>
-            </plugin>        
+            </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -329,6 +329,7 @@
             <artifactId>jersey-media-json-jackson</artifactId>
             <version>${jersey-version}</version>
         </dependency>
+        <!-- Pinned because other libraries rely on this lib and jersey is not backwards compatible now -->
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>

--- a/src/main/java/com/docusign/admin/api/ProvisionAssetGroupApi.java
+++ b/src/main/java/com/docusign/admin/api/ProvisionAssetGroupApi.java
@@ -1,0 +1,466 @@
+
+package com.docusign.admin.api;
+
+import jakarta.ws.rs.core.GenericType;
+
+import com.docusign.admin.client.ApiException;
+import com.docusign.admin.client.ApiClient;
+import com.docusign.admin.client.Configuration;
+import com.docusign.admin.model.*;
+import com.docusign.admin.client.Pair;
+import com.docusign.admin.client.ApiResponse;
+
+
+
+
+/**
+ * ProvisionAssetGroupApi class.
+ *
+ **/
+public class ProvisionAssetGroupApi {
+  private ApiClient apiClient;
+
+ /**
+  * ProvisionAssetGroupApi.
+  *
+  **/
+  public ProvisionAssetGroupApi() {
+    this(Configuration.getDefaultApiClient());
+  }
+
+ /**
+  * ProvisionAssetGroupApi.
+  *
+  **/
+  public ProvisionAssetGroupApi(ApiClient apiClient) {
+    this.apiClient = apiClient;
+  }
+
+ /**
+  * getApiClient Method.
+  *
+  * @return ApiClient
+  **/
+  public ApiClient getApiClient() {
+    return apiClient;
+  }
+
+ /**
+  * setApiClient Method.
+  *
+  **/
+  public void setApiClient(ApiClient apiClient) {
+    this.apiClient = apiClient;
+  }
+
+
+  /**
+   * Clones an existing DocuSign account to a new DocuSign account..
+   * Currently this only clones eSign settings and asset group information.  Required scopes: asset_group_account_clone_write
+   * @param organizationId The Guid representing the organization id. (required)
+   * @param request The request defails for the new asset group account clone. (required)
+   * @return AssetGroupAccountClone
+   * @throws ApiException if fails to make API call
+   */
+  public AssetGroupAccountClone cloneAssetGroupAccount(java.util.UUID organizationId, AssetGroupAccountClone request) throws ApiException {
+    ApiResponse<AssetGroupAccountClone> localVarResponse = cloneAssetGroupAccountWithHttpInfo(organizationId, request);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Clones an existing DocuSign account to a new DocuSign account.
+   * Currently this only clones eSign settings and asset group information.  Required scopes: asset_group_account_clone_write
+   * @param organizationId The Guid representing the organization id. (required)
+   * @param request The request defails for the new asset group account clone. (required)
+   * @return AssetGroupAccountClone
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<AssetGroupAccountClone > cloneAssetGroupAccountWithHttpInfo(java.util.UUID organizationId, AssetGroupAccountClone request) throws ApiException {
+    Object localVarPostBody = request;
+    
+    // verify the required parameter 'organizationId' is set
+    if (organizationId == null) {
+      throw new ApiException(400, "Missing the required parameter 'organizationId' when calling cloneAssetGroupAccount");
+    }
+    
+    // verify the required parameter 'request' is set
+    if (request == null) {
+      throw new ApiException(400, "Missing the required parameter 'request' when calling cloneAssetGroupAccount");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/v1/organizations/{organizationId}/assetGroups/accountClone"
+      .replaceAll("\\{" + "organizationId" + "\\}", apiClient.escapeString(organizationId.toString()));
+
+    // query params
+    java.util.List<Pair> localVarQueryParams = new java.util.ArrayList<Pair>();
+    java.util.List<Pair> localVarCollectionQueryParams = new java.util.ArrayList<Pair>();
+    java.util.Map<String, String> localVarHeaderParams = new java.util.HashMap<String, String>();
+    java.util.Map<String, Object> localVarFormParams = new java.util.HashMap<String, Object>();
+
+    
+
+    
+
+    
+
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+    
+    GenericType<AssetGroupAccountClone> localVarReturnType = new GenericType<AssetGroupAccountClone>() {};
+    AssetGroupAccountClone localVarResponse = apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return new ApiResponse<AssetGroupAccountClone>(apiClient.getStatusCode(), apiClient.getResponseHeaders(), localVarResponse);
+  }
+  /// <summary>
+  /// Gets an asset group account clone by the asset group work id. Required scopes: asset_group_account_clone_read
+  /// </summary>
+
+ /**
+  * GetAssetGroupAccountCloneOptions Class.
+  *
+  **/
+  public class GetAssetGroupAccountCloneOptions
+  {
+  private Boolean includeDetails = null;
+  
+ /**
+  * setIncludeDetails method.
+  */
+  public void setIncludeDetails(Boolean includeDetails) {
+    this.includeDetails = includeDetails;
+  }
+
+ /**
+  * getIncludeDetails method.
+  *
+  * @return Boolean
+  */
+  public Boolean getIncludeDetails() {
+    return this.includeDetails;
+  }
+  }
+
+   /**
+   * Gets an asset group account clone by the asset group work id..
+   * Required scopes: asset_group_account_clone_read
+   * @param organizationId The Guid representing the organization id. (required)
+   * @param assetGroupId The Guid representing the asset group id. (required)
+   * @param assetGroupWorkId The Guid representing the asset group account clone id (required)
+   * @return AssetGroupAccountClone
+   */ 
+  public AssetGroupAccountClone getAssetGroupAccountClone(java.util.UUID organizationId, java.util.UUID assetGroupId, java.util.UUID assetGroupWorkId) throws ApiException {
+    return getAssetGroupAccountClone(organizationId, assetGroupId, assetGroupWorkId, null);
+  }
+
+  /**
+   * Gets an asset group account clone by the asset group work id..
+   * Required scopes: asset_group_account_clone_read
+   * @param organizationId The Guid representing the organization id. (required)
+   * @param assetGroupId The Guid representing the asset group id. (required)
+   * @param assetGroupWorkId The Guid representing the asset group account clone id (required)
+   * @param options for modifying the method behavior.
+   * @return AssetGroupAccountClone
+   * @throws ApiException if fails to make API call
+   */
+  public AssetGroupAccountClone getAssetGroupAccountClone(java.util.UUID organizationId, java.util.UUID assetGroupId, java.util.UUID assetGroupWorkId, ProvisionAssetGroupApi.GetAssetGroupAccountCloneOptions options) throws ApiException {
+    ApiResponse<AssetGroupAccountClone> localVarResponse = getAssetGroupAccountCloneWithHttpInfo(organizationId, assetGroupId, assetGroupWorkId, options);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Gets an asset group account clone by the asset group work id.
+   * Required scopes: asset_group_account_clone_read
+   * @param organizationId The Guid representing the organization id. (required)
+   * @param assetGroupId The Guid representing the asset group id. (required)
+   * @param assetGroupWorkId The Guid representing the asset group account clone id (required)
+   * @param options for modifying the method behavior.
+   * @return AssetGroupAccountClone
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<AssetGroupAccountClone > getAssetGroupAccountCloneWithHttpInfo(java.util.UUID organizationId, java.util.UUID assetGroupId, java.util.UUID assetGroupWorkId, ProvisionAssetGroupApi.GetAssetGroupAccountCloneOptions options) throws ApiException {
+    Object localVarPostBody = "{}";
+    
+    // verify the required parameter 'organizationId' is set
+    if (organizationId == null) {
+      throw new ApiException(400, "Missing the required parameter 'organizationId' when calling getAssetGroupAccountClone");
+    }
+    
+    // verify the required parameter 'assetGroupId' is set
+    if (assetGroupId == null) {
+      throw new ApiException(400, "Missing the required parameter 'assetGroupId' when calling getAssetGroupAccountClone");
+    }
+    
+    // verify the required parameter 'assetGroupWorkId' is set
+    if (assetGroupWorkId == null) {
+      throw new ApiException(400, "Missing the required parameter 'assetGroupWorkId' when calling getAssetGroupAccountClone");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/v1/organizations/{organizationId}/assetGroups/{assetGroupId}/accountClones/{assetGroupWorkId}"
+      .replaceAll("\\{" + "organizationId" + "\\}", apiClient.escapeString(organizationId.toString()))
+      .replaceAll("\\{" + "assetGroupId" + "\\}", apiClient.escapeString(assetGroupId.toString()))
+      .replaceAll("\\{" + "assetGroupWorkId" + "\\}", apiClient.escapeString(assetGroupWorkId.toString()));
+
+    // query params
+    java.util.List<Pair> localVarQueryParams = new java.util.ArrayList<Pair>();
+    java.util.List<Pair> localVarCollectionQueryParams = new java.util.ArrayList<Pair>();
+    java.util.Map<String, String> localVarHeaderParams = new java.util.HashMap<String, String>();
+    java.util.Map<String, Object> localVarFormParams = new java.util.HashMap<String, Object>();
+
+    if (options != null) {
+      localVarQueryParams.addAll(apiClient.parameterToPair("include_details", options.includeDetails));
+    }
+
+    
+
+    
+
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+    
+    GenericType<AssetGroupAccountClone> localVarReturnType = new GenericType<AssetGroupAccountClone>() {};
+    AssetGroupAccountClone localVarResponse = apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return new ApiResponse<AssetGroupAccountClone>(apiClient.getStatusCode(), apiClient.getResponseHeaders(), localVarResponse);
+  }
+  /// <summary>
+  /// Gets all asset group account clone(s) for an organization id. Required scopes: asset_group_account_clone_read
+  /// </summary>
+
+ /**
+  * GetAssetGroupAccountClonesByOrgIdOptions Class.
+  *
+  **/
+  public class GetAssetGroupAccountClonesByOrgIdOptions
+  {
+  private String sinceUpdatedDate = null;
+  private Boolean includeDetails = null;
+  
+ /**
+  * setSinceUpdatedDate method.
+  */
+  public void setSinceUpdatedDate(String sinceUpdatedDate) {
+    this.sinceUpdatedDate = sinceUpdatedDate;
+  }
+
+ /**
+  * getSinceUpdatedDate method.
+  *
+  * @return String
+  */
+  public String getSinceUpdatedDate() {
+    return this.sinceUpdatedDate;
+  }
+  
+ /**
+  * setIncludeDetails method.
+  */
+  public void setIncludeDetails(Boolean includeDetails) {
+    this.includeDetails = includeDetails;
+  }
+
+ /**
+  * getIncludeDetails method.
+  *
+  * @return Boolean
+  */
+  public Boolean getIncludeDetails() {
+    return this.includeDetails;
+  }
+  }
+
+   /**
+   * Gets all asset group account clone(s) for an organization id..
+   * Required scopes: asset_group_account_clone_read
+   * @param organizationId The Guid representing the organization id. (required)
+   * @return AssetGroupAccountClones
+   */ 
+  public AssetGroupAccountClones getAssetGroupAccountClonesByOrgId(java.util.UUID organizationId) throws ApiException {
+    return getAssetGroupAccountClonesByOrgId(organizationId, null);
+  }
+
+  /**
+   * Gets all asset group account clone(s) for an organization id..
+   * Required scopes: asset_group_account_clone_read
+   * @param organizationId The Guid representing the organization id. (required)
+   * @param options for modifying the method behavior.
+   * @return AssetGroupAccountClones
+   * @throws ApiException if fails to make API call
+   */
+  public AssetGroupAccountClones getAssetGroupAccountClonesByOrgId(java.util.UUID organizationId, ProvisionAssetGroupApi.GetAssetGroupAccountClonesByOrgIdOptions options) throws ApiException {
+    ApiResponse<AssetGroupAccountClones> localVarResponse = getAssetGroupAccountClonesByOrgIdWithHttpInfo(organizationId, options);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Gets all asset group account clone(s) for an organization id.
+   * Required scopes: asset_group_account_clone_read
+   * @param organizationId The Guid representing the organization id. (required)
+   * @param options for modifying the method behavior.
+   * @return AssetGroupAccountClones
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<AssetGroupAccountClones > getAssetGroupAccountClonesByOrgIdWithHttpInfo(java.util.UUID organizationId, ProvisionAssetGroupApi.GetAssetGroupAccountClonesByOrgIdOptions options) throws ApiException {
+    Object localVarPostBody = "{}";
+    
+    // verify the required parameter 'organizationId' is set
+    if (organizationId == null) {
+      throw new ApiException(400, "Missing the required parameter 'organizationId' when calling getAssetGroupAccountClonesByOrgId");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/v1/organizations/{organizationId}/assetGroups/accountClones"
+      .replaceAll("\\{" + "organizationId" + "\\}", apiClient.escapeString(organizationId.toString()));
+
+    // query params
+    java.util.List<Pair> localVarQueryParams = new java.util.ArrayList<Pair>();
+    java.util.List<Pair> localVarCollectionQueryParams = new java.util.ArrayList<Pair>();
+    java.util.Map<String, String> localVarHeaderParams = new java.util.HashMap<String, String>();
+    java.util.Map<String, Object> localVarFormParams = new java.util.HashMap<String, Object>();
+
+    if (options != null) {
+      localVarQueryParams.addAll(apiClient.parameterToPair("since_updated_date", options.sinceUpdatedDate));
+    }if (options != null) {
+      localVarQueryParams.addAll(apiClient.parameterToPair("include_details", options.includeDetails));
+    }
+
+    
+
+    
+
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+    
+    GenericType<AssetGroupAccountClones> localVarReturnType = new GenericType<AssetGroupAccountClones>() {};
+    AssetGroupAccountClones localVarResponse = apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return new ApiResponse<AssetGroupAccountClones>(apiClient.getStatusCode(), apiClient.getResponseHeaders(), localVarResponse);
+  }
+  /// <summary>
+  /// Get all accounts in asset groups for the organization. Required scopes: asset_group_account_read
+  /// </summary>
+
+ /**
+  * GetAssetGroupAccountsOptions Class.
+  *
+  **/
+  public class GetAssetGroupAccountsOptions
+  {
+  private Boolean compliant = null;
+  
+ /**
+  * setCompliant method.
+  */
+  public void setCompliant(Boolean compliant) {
+    this.compliant = compliant;
+  }
+
+ /**
+  * getCompliant method.
+  *
+  * @return Boolean
+  */
+  public Boolean getCompliant() {
+    return this.compliant;
+  }
+  }
+
+   /**
+   * Get all accounts in asset groups for the organization..
+   * Required scopes: asset_group_account_read
+   * @param organizationId The Guid representing the organization id. (required)
+   * @return AssetGroupAccountsResponse
+   */ 
+  public AssetGroupAccountsResponse getAssetGroupAccounts(java.util.UUID organizationId) throws ApiException {
+    return getAssetGroupAccounts(organizationId, null);
+  }
+
+  /**
+   * Get all accounts in asset groups for the organization..
+   * Required scopes: asset_group_account_read
+   * @param organizationId The Guid representing the organization id. (required)
+   * @param options for modifying the method behavior.
+   * @return AssetGroupAccountsResponse
+   * @throws ApiException if fails to make API call
+   */
+  public AssetGroupAccountsResponse getAssetGroupAccounts(java.util.UUID organizationId, ProvisionAssetGroupApi.GetAssetGroupAccountsOptions options) throws ApiException {
+    ApiResponse<AssetGroupAccountsResponse> localVarResponse = getAssetGroupAccountsWithHttpInfo(organizationId, options);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Get all accounts in asset groups for the organization.
+   * Required scopes: asset_group_account_read
+   * @param organizationId The Guid representing the organization id. (required)
+   * @param options for modifying the method behavior.
+   * @return AssetGroupAccountsResponse
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<AssetGroupAccountsResponse > getAssetGroupAccountsWithHttpInfo(java.util.UUID organizationId, ProvisionAssetGroupApi.GetAssetGroupAccountsOptions options) throws ApiException {
+    Object localVarPostBody = "{}";
+    
+    // verify the required parameter 'organizationId' is set
+    if (organizationId == null) {
+      throw new ApiException(400, "Missing the required parameter 'organizationId' when calling getAssetGroupAccounts");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/v1/organizations/{organizationId}/assetGroups/accounts"
+      .replaceAll("\\{" + "organizationId" + "\\}", apiClient.escapeString(organizationId.toString()));
+
+    // query params
+    java.util.List<Pair> localVarQueryParams = new java.util.ArrayList<Pair>();
+    java.util.List<Pair> localVarCollectionQueryParams = new java.util.ArrayList<Pair>();
+    java.util.Map<String, String> localVarHeaderParams = new java.util.HashMap<String, String>();
+    java.util.Map<String, Object> localVarFormParams = new java.util.HashMap<String, Object>();
+
+    if (options != null) {
+      localVarQueryParams.addAll(apiClient.parameterToPair("compliant", options.compliant));
+    }
+
+    
+
+    
+
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+    
+    GenericType<AssetGroupAccountsResponse> localVarReturnType = new GenericType<AssetGroupAccountsResponse>() {};
+    AssetGroupAccountsResponse localVarResponse = apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    return new ApiResponse<AssetGroupAccountsResponse>(apiClient.getStatusCode(), apiClient.getResponseHeaders(), localVarResponse);
+  }
+}

--- a/src/main/java/com/docusign/admin/client/ApiClient.java
+++ b/src/main/java/com/docusign/admin/client/ApiClient.java
@@ -96,7 +96,7 @@ public class ApiClient {
     String javaVersion = System.getProperty("java.version");
 
     // Set default User-Agent.
-    setUserAgent("/SDK/1.2.0/Java/");
+    setUserAgent("/SDK/1.3.0/Java/");
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();

--- a/src/main/java/com/docusign/admin/model/AssetGroupAccountClone.java
+++ b/src/main/java/com/docusign/admin/model/AssetGroupAccountClone.java
@@ -1,0 +1,390 @@
+package com.docusign.admin.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.docusign.admin.model.AssetGroupAccountCloneSourceAccount;
+import com.docusign.admin.model.AssetGroupAccountCloneTargetAccount;
+import com.docusign.admin.model.CloneErrorDetails;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.OffsetDateTime;
+
+/**
+ * AssetGroupAccountClone.
+ *
+ */
+
+public class AssetGroupAccountClone {
+  @JsonProperty("sourceAccount")
+  private AssetGroupAccountCloneSourceAccount sourceAccount = null;
+
+  @JsonProperty("targetAccount")
+  private AssetGroupAccountCloneTargetAccount targetAccount = null;
+
+  @JsonProperty("assetGroupWorkId")
+  private java.util.UUID assetGroupWorkId = null;
+
+  @JsonProperty("assetGroupId")
+  private java.util.UUID assetGroupId = null;
+
+  /**
+   * The type of asset group work.
+   */
+  public enum AssetGroupWorkTypeEnum {
+    UNDEFINED("Undefined"),
+    
+    GROUPASSETFULFILLMENT("GroupAssetFulfillment"),
+    
+    ACCOUNTASSETFULFILLMENT("AccountAssetFulfillment"),
+    
+    ACCOUNTASSETCLONE("AccountAssetClone"),
+    
+    ACCOUNTASSETCREATE("AccountAssetCreate");
+
+    private String value;
+
+    AssetGroupWorkTypeEnum(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static AssetGroupWorkTypeEnum fromValue(String value) {
+      for (AssetGroupWorkTypeEnum b : AssetGroupWorkTypeEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      return null;
+    }
+  }
+
+  @JsonProperty("assetGroupWorkType")
+  private AssetGroupWorkTypeEnum assetGroupWorkType = null;
+
+  /**
+   * The clone status.
+   */
+  public enum StatusEnum {
+    UNDEFINED("Undefined"),
+    
+    PENDING("Pending"),
+    
+    PROCESSING("Processing"),
+    
+    PENDINGERROR("PendingError"),
+    
+    PROCESSINGERROR("ProcessingError"),
+    
+    COMPLETED("Completed"),
+    
+    CANCELED("Canceled"),
+    
+    PERMANENTFAILURE("PermanentFailure");
+
+    private String value;
+
+    StatusEnum(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String value) {
+      for (StatusEnum b : StatusEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      return null;
+    }
+  }
+
+  @JsonProperty("status")
+  private StatusEnum status = null;
+
+  @JsonProperty("cloneRequestId")
+  private java.util.UUID cloneRequestId = null;
+
+  @JsonProperty("orderId")
+  private java.util.UUID orderId = null;
+
+  @JsonProperty("attempts")
+  private Integer attempts = null;
+
+  @JsonProperty("createdDate")
+  private String createdDate = null;
+
+  @JsonProperty("createdByName")
+  private String createdByName = null;
+
+  @JsonProperty("createdByEmail")
+  private String createdByEmail = null;
+
+  @JsonProperty("message")
+  private String message = null;
+
+  @JsonProperty("cloneProcessingFailureDetails")
+  private CloneErrorDetails cloneProcessingFailureDetails = null;
+
+
+  /**
+   * sourceAccount.
+   *
+   * @return AssetGroupAccountClone
+   **/
+  public AssetGroupAccountClone sourceAccount(AssetGroupAccountCloneSourceAccount sourceAccount) {
+    this.sourceAccount = sourceAccount;
+    return this;
+  }
+
+  /**
+   * The source account to be cloned from..
+   * @return sourceAccount
+   **/
+  @Schema(required = true, description = "The source account to be cloned from.")
+  public AssetGroupAccountCloneSourceAccount getSourceAccount() {
+    return sourceAccount;
+  }
+
+  /**
+   * setSourceAccount.
+   **/
+  public void setSourceAccount(AssetGroupAccountCloneSourceAccount sourceAccount) {
+    this.sourceAccount = sourceAccount;
+  }
+
+
+  /**
+   * targetAccount.
+   *
+   * @return AssetGroupAccountClone
+   **/
+  public AssetGroupAccountClone targetAccount(AssetGroupAccountCloneTargetAccount targetAccount) {
+    this.targetAccount = targetAccount;
+    return this;
+  }
+
+  /**
+   * The target account to clone to..
+   * @return targetAccount
+   **/
+  @Schema(required = true, description = "The target account to clone to.")
+  public AssetGroupAccountCloneTargetAccount getTargetAccount() {
+    return targetAccount;
+  }
+
+  /**
+   * setTargetAccount.
+   **/
+  public void setTargetAccount(AssetGroupAccountCloneTargetAccount targetAccount) {
+    this.targetAccount = targetAccount;
+  }
+
+  /**
+   * The account clone work id..
+   * @return assetGroupWorkId
+   **/
+  @Schema(example = "00000000-0000-0000-0000-000000000000", description = "The account clone work id.")
+  public java.util.UUID getAssetGroupWorkId() {
+    return assetGroupWorkId;
+  }
+
+  /**
+   * The asset group id the accounts belong to..
+   * @return assetGroupId
+   **/
+  @Schema(example = "00000000-0000-0000-0000-000000000000", description = "The asset group id the accounts belong to.")
+  public java.util.UUID getAssetGroupId() {
+    return assetGroupId;
+  }
+
+  /**
+   * The type of asset group work..
+   * @return assetGroupWorkType
+   **/
+  @Schema(description = "The type of asset group work.")
+  public AssetGroupWorkTypeEnum getAssetGroupWorkType() {
+    return assetGroupWorkType;
+  }
+
+  /**
+   * The clone status..
+   * @return status
+   **/
+  @Schema(description = "The clone status.")
+  public StatusEnum getStatus() {
+    return status;
+  }
+
+  /**
+   * The account entitlement/setting mirror request id created by the clone work..
+   * @return cloneRequestId
+   **/
+  @Schema(example = "00000000-0000-0000-0000-000000000000", description = "The account entitlement/setting mirror request id created by the clone work.")
+  public java.util.UUID getCloneRequestId() {
+    return cloneRequestId;
+  }
+
+  /**
+   * The order id created by the clone work..
+   * @return orderId
+   **/
+  @Schema(example = "00000000-0000-0000-0000-000000000000", description = "The order id created by the clone work.")
+  public java.util.UUID getOrderId() {
+    return orderId;
+  }
+
+  /**
+   * The number of times the work has been worked on..
+   * @return attempts
+   **/
+  @Schema(description = "The number of times the work has been worked on.")
+  public Integer getAttempts() {
+    return attempts;
+  }
+
+  /**
+   * The date the account clone work is created..
+   * @return createdDate
+   **/
+  @Schema(description = "The date the account clone work is created.")
+  public String getCreatedDate() {
+    return createdDate;
+  }
+
+  /**
+   * The name of the creator of the account clone work..
+   * @return createdByName
+   **/
+  @Schema(description = "The name of the creator of the account clone work.")
+  public String getCreatedByName() {
+    return createdByName;
+  }
+
+  /**
+   * The email of the creator of the account clone work..
+   * @return createdByEmail
+   **/
+  @Schema(description = "The email of the creator of the account clone work.")
+  public String getCreatedByEmail() {
+    return createdByEmail;
+  }
+
+  /**
+   * The message associated with the account clone work..
+   * @return message
+   **/
+  @Schema(description = "The message associated with the account clone work.")
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * The processing failures if the work is in PendingError/ProcessingError status..
+   * @return cloneProcessingFailureDetails
+   **/
+  @Schema(description = "The processing failures if the work is in PendingError/ProcessingError status.")
+  public CloneErrorDetails getCloneProcessingFailureDetails() {
+    return cloneProcessingFailureDetails;
+  }
+
+
+  /**
+   * Compares objects.
+   *
+   * @return true or false depending on comparison result.
+   */
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AssetGroupAccountClone assetGroupAccountClone = (AssetGroupAccountClone) o;
+    return Objects.equals(this.sourceAccount, assetGroupAccountClone.sourceAccount) &&
+        Objects.equals(this.targetAccount, assetGroupAccountClone.targetAccount) &&
+        Objects.equals(this.assetGroupWorkId, assetGroupAccountClone.assetGroupWorkId) &&
+        Objects.equals(this.assetGroupId, assetGroupAccountClone.assetGroupId) &&
+        Objects.equals(this.assetGroupWorkType, assetGroupAccountClone.assetGroupWorkType) &&
+        Objects.equals(this.status, assetGroupAccountClone.status) &&
+        Objects.equals(this.cloneRequestId, assetGroupAccountClone.cloneRequestId) &&
+        Objects.equals(this.orderId, assetGroupAccountClone.orderId) &&
+        Objects.equals(this.attempts, assetGroupAccountClone.attempts) &&
+        Objects.equals(this.createdDate, assetGroupAccountClone.createdDate) &&
+        Objects.equals(this.createdByName, assetGroupAccountClone.createdByName) &&
+        Objects.equals(this.createdByEmail, assetGroupAccountClone.createdByEmail) &&
+        Objects.equals(this.message, assetGroupAccountClone.message) &&
+        Objects.equals(this.cloneProcessingFailureDetails, assetGroupAccountClone.cloneProcessingFailureDetails);
+  }
+
+  /**
+   * Returns the HashCode.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceAccount, targetAccount, assetGroupWorkId, assetGroupId, assetGroupWorkType, status, cloneRequestId, orderId, attempts, createdDate, createdByName, createdByEmail, message, cloneProcessingFailureDetails);
+  }
+
+
+  /**
+   * Converts the given object to string.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AssetGroupAccountClone {\n");
+    
+    sb.append("    sourceAccount: ").append(toIndentedString(sourceAccount)).append("\n");
+    sb.append("    targetAccount: ").append(toIndentedString(targetAccount)).append("\n");
+    sb.append("    assetGroupWorkId: ").append(toIndentedString(assetGroupWorkId)).append("\n");
+    sb.append("    assetGroupId: ").append(toIndentedString(assetGroupId)).append("\n");
+    sb.append("    assetGroupWorkType: ").append(toIndentedString(assetGroupWorkType)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    cloneRequestId: ").append(toIndentedString(cloneRequestId)).append("\n");
+    sb.append("    orderId: ").append(toIndentedString(orderId)).append("\n");
+    sb.append("    attempts: ").append(toIndentedString(attempts)).append("\n");
+    sb.append("    createdDate: ").append(toIndentedString(createdDate)).append("\n");
+    sb.append("    createdByName: ").append(toIndentedString(createdByName)).append("\n");
+    sb.append("    createdByEmail: ").append(toIndentedString(createdByEmail)).append("\n");
+    sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("    cloneProcessingFailureDetails: ").append(toIndentedString(cloneProcessingFailureDetails)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/src/main/java/com/docusign/admin/model/AssetGroupAccountCloneSourceAccount.java
+++ b/src/main/java/com/docusign/admin/model/AssetGroupAccountCloneSourceAccount.java
@@ -1,0 +1,140 @@
+package com.docusign.admin.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * AssetGroupAccountCloneSourceAccount.
+ *
+ */
+
+public class AssetGroupAccountCloneSourceAccount {
+  @JsonProperty("id")
+  private java.util.UUID id = null;
+
+  @JsonProperty("externalAccountId")
+  private Long externalAccountId = null;
+
+  @JsonProperty("site")
+  private String site = null;
+
+  @JsonProperty("name")
+  private String name = null;
+
+
+  /**
+   * id.
+   *
+   * @return AssetGroupAccountCloneSourceAccount
+   **/
+  public AssetGroupAccountCloneSourceAccount id(java.util.UUID id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * The source account id to clone from..
+   * @return id
+   **/
+  @Schema(example = "00000000-0000-0000-0000-000000000000", required = true, description = "The source account id to clone from.")
+  public java.util.UUID getId() {
+    return id;
+  }
+
+  /**
+   * setId.
+   **/
+  public void setId(java.util.UUID id) {
+    this.id = id;
+  }
+
+  /**
+   * The external account id of the source account..
+   * @return externalAccountId
+   **/
+  @Schema(description = "The external account id of the source account.")
+  public Long getExternalAccountId() {
+    return externalAccountId;
+  }
+
+  /**
+   * The site the source account is on..
+   * @return site
+   **/
+  @Schema(description = "The site the source account is on.")
+  public String getSite() {
+    return site;
+  }
+
+  /**
+   * The name of the source account..
+   * @return name
+   **/
+  @Schema(description = "The name of the source account.")
+  public String getName() {
+    return name;
+  }
+
+
+  /**
+   * Compares objects.
+   *
+   * @return true or false depending on comparison result.
+   */
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AssetGroupAccountCloneSourceAccount assetGroupAccountCloneSourceAccount = (AssetGroupAccountCloneSourceAccount) o;
+    return Objects.equals(this.id, assetGroupAccountCloneSourceAccount.id) &&
+        Objects.equals(this.externalAccountId, assetGroupAccountCloneSourceAccount.externalAccountId) &&
+        Objects.equals(this.site, assetGroupAccountCloneSourceAccount.site) &&
+        Objects.equals(this.name, assetGroupAccountCloneSourceAccount.name);
+  }
+
+  /**
+   * Returns the HashCode.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, externalAccountId, site, name);
+  }
+
+
+  /**
+   * Converts the given object to string.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AssetGroupAccountCloneSourceAccount {\n");
+    
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
+    sb.append("    externalAccountId: ").append(toIndentedString(externalAccountId)).append("\n");
+    sb.append("    site: ").append(toIndentedString(site)).append("\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/src/main/java/com/docusign/admin/model/AssetGroupAccountCloneTargetAccount.java
+++ b/src/main/java/com/docusign/admin/model/AssetGroupAccountCloneTargetAccount.java
@@ -1,0 +1,259 @@
+package com.docusign.admin.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.docusign.admin.model.AssetGroupAccountCloneTargetAccountAdmin;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * AssetGroupAccountCloneTargetAccount.
+ *
+ */
+
+public class AssetGroupAccountCloneTargetAccount {
+  @JsonProperty("id")
+  private java.util.UUID id = null;
+
+  @JsonProperty("name")
+  private String name = null;
+
+  @JsonProperty("region")
+  private String region = null;
+
+  @JsonProperty("countryCode")
+  private String countryCode = null;
+
+  @JsonProperty("site")
+  private String site = null;
+
+  @JsonProperty("admin")
+  private AssetGroupAccountCloneTargetAccountAdmin admin = null;
+
+
+  /**
+   * id.
+   *
+   * @return AssetGroupAccountCloneTargetAccount
+   **/
+  public AssetGroupAccountCloneTargetAccount id(java.util.UUID id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * The target account id to clone to. It will be empty Guid if account not yet created..
+   * @return id
+   **/
+  @Schema(example = "00000000-0000-0000-0000-000000000000", description = "The target account id to clone to. It will be empty Guid if account not yet created.")
+  public java.util.UUID getId() {
+    return id;
+  }
+
+  /**
+   * setId.
+   **/
+  public void setId(java.util.UUID id) {
+    this.id = id;
+  }
+
+
+  /**
+   * name.
+   *
+   * @return AssetGroupAccountCloneTargetAccount
+   **/
+  public AssetGroupAccountCloneTargetAccount name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * The name of the target account..
+   * @return name
+   **/
+  @Schema(description = "The name of the target account.")
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * setName.
+   **/
+  public void setName(String name) {
+    this.name = name;
+  }
+
+
+  /**
+   * region.
+   *
+   * @return AssetGroupAccountCloneTargetAccount
+   **/
+  public AssetGroupAccountCloneTargetAccount region(String region) {
+    this.region = region;
+    return this;
+  }
+
+  /**
+   * The region where the target account is in..
+   * @return region
+   **/
+  @Schema(description = "The region where the target account is in.")
+  public String getRegion() {
+    return region;
+  }
+
+  /**
+   * setRegion.
+   **/
+  public void setRegion(String region) {
+    this.region = region;
+  }
+
+
+  /**
+   * countryCode.
+   *
+   * @return AssetGroupAccountCloneTargetAccount
+   **/
+  public AssetGroupAccountCloneTargetAccount countryCode(String countryCode) {
+    this.countryCode = countryCode;
+    return this;
+  }
+
+  /**
+   * The country code where the target account is in. This value is ignored if region is provided..
+   * @return countryCode
+   **/
+  @Schema(description = "The country code where the target account is in. This value is ignored if region is provided.")
+  public String getCountryCode() {
+    return countryCode;
+  }
+
+  /**
+   * setCountryCode.
+   **/
+  public void setCountryCode(String countryCode) {
+    this.countryCode = countryCode;
+  }
+
+
+  /**
+   * site.
+   *
+   * @return AssetGroupAccountCloneTargetAccount
+   **/
+  public AssetGroupAccountCloneTargetAccount site(String site) {
+    this.site = site;
+    return this;
+  }
+
+  /**
+   * The site where the target account is on..
+   * @return site
+   **/
+  @Schema(description = "The site where the target account is on.")
+  public String getSite() {
+    return site;
+  }
+
+  /**
+   * setSite.
+   **/
+  public void setSite(String site) {
+    this.site = site;
+  }
+
+
+  /**
+   * admin.
+   *
+   * @return AssetGroupAccountCloneTargetAccount
+   **/
+  public AssetGroupAccountCloneTargetAccount admin(AssetGroupAccountCloneTargetAccountAdmin admin) {
+    this.admin = admin;
+    return this;
+  }
+
+  /**
+   * The admin user for the target account..
+   * @return admin
+   **/
+  @Schema(description = "The admin user for the target account.")
+  public AssetGroupAccountCloneTargetAccountAdmin getAdmin() {
+    return admin;
+  }
+
+  /**
+   * setAdmin.
+   **/
+  public void setAdmin(AssetGroupAccountCloneTargetAccountAdmin admin) {
+    this.admin = admin;
+  }
+
+
+  /**
+   * Compares objects.
+   *
+   * @return true or false depending on comparison result.
+   */
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AssetGroupAccountCloneTargetAccount assetGroupAccountCloneTargetAccount = (AssetGroupAccountCloneTargetAccount) o;
+    return Objects.equals(this.id, assetGroupAccountCloneTargetAccount.id) &&
+        Objects.equals(this.name, assetGroupAccountCloneTargetAccount.name) &&
+        Objects.equals(this.region, assetGroupAccountCloneTargetAccount.region) &&
+        Objects.equals(this.countryCode, assetGroupAccountCloneTargetAccount.countryCode) &&
+        Objects.equals(this.site, assetGroupAccountCloneTargetAccount.site) &&
+        Objects.equals(this.admin, assetGroupAccountCloneTargetAccount.admin);
+  }
+
+  /**
+   * Returns the HashCode.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, region, countryCode, site, admin);
+  }
+
+
+  /**
+   * Converts the given object to string.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AssetGroupAccountCloneTargetAccount {\n");
+    
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    region: ").append(toIndentedString(region)).append("\n");
+    sb.append("    countryCode: ").append(toIndentedString(countryCode)).append("\n");
+    sb.append("    site: ").append(toIndentedString(site)).append("\n");
+    sb.append("    admin: ").append(toIndentedString(admin)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/src/main/java/com/docusign/admin/model/AssetGroupAccountCloneTargetAccountAdmin.java
+++ b/src/main/java/com/docusign/admin/model/AssetGroupAccountCloneTargetAccountAdmin.java
@@ -1,0 +1,255 @@
+package com.docusign.admin.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * AssetGroupAccountCloneTargetAccountAdmin.
+ *
+ */
+
+public class AssetGroupAccountCloneTargetAccountAdmin {
+  @JsonProperty("email")
+  private String email = null;
+
+  @JsonProperty("firstName")
+  private String firstName = null;
+
+  @JsonProperty("lastName")
+  private String lastName = null;
+
+  /**
+   * The locale of the target account&#39;s admin user.
+   */
+  public enum LocaleEnum {
+    NONE("None"),
+    
+    ZH_CN("zh_cn"),
+    
+    ZH_TW("zh_tw"),
+    
+    NL("nl"),
+    
+    EN("en"),
+    
+    FR("fr"),
+    
+    DE("de"),
+    
+    IT("it"),
+    
+    JA("ja"),
+    
+    KO("ko"),
+    
+    PT("pt"),
+    
+    PT_BR("pt_br"),
+    
+    RU("ru"),
+    
+    ES("es"),
+    
+    PL("pl");
+
+    private String value;
+
+    LocaleEnum(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static LocaleEnum fromValue(String value) {
+      for (LocaleEnum b : LocaleEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      return null;
+    }
+  }
+
+  @JsonProperty("locale")
+  private LocaleEnum locale = null;
+
+
+  /**
+   * email.
+   *
+   * @return AssetGroupAccountCloneTargetAccountAdmin
+   **/
+  public AssetGroupAccountCloneTargetAccountAdmin email(String email) {
+    this.email = email;
+    return this;
+  }
+
+  /**
+   * The email of the target account's admin user..
+   * @return email
+   **/
+  @Schema(description = "The email of the target account's admin user.")
+  public String getEmail() {
+    return email;
+  }
+
+  /**
+   * setEmail.
+   **/
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+
+  /**
+   * firstName.
+   *
+   * @return AssetGroupAccountCloneTargetAccountAdmin
+   **/
+  public AssetGroupAccountCloneTargetAccountAdmin firstName(String firstName) {
+    this.firstName = firstName;
+    return this;
+  }
+
+  /**
+   * The first name of the target account's admin user..
+   * @return firstName
+   **/
+  @Schema(description = "The first name of the target account's admin user.")
+  public String getFirstName() {
+    return firstName;
+  }
+
+  /**
+   * setFirstName.
+   **/
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+
+  /**
+   * lastName.
+   *
+   * @return AssetGroupAccountCloneTargetAccountAdmin
+   **/
+  public AssetGroupAccountCloneTargetAccountAdmin lastName(String lastName) {
+    this.lastName = lastName;
+    return this;
+  }
+
+  /**
+   * The last name of the target account's admin user..
+   * @return lastName
+   **/
+  @Schema(description = "The last name of the target account's admin user.")
+  public String getLastName() {
+    return lastName;
+  }
+
+  /**
+   * setLastName.
+   **/
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+
+  /**
+   * locale.
+   *
+   * @return AssetGroupAccountCloneTargetAccountAdmin
+   **/
+  public AssetGroupAccountCloneTargetAccountAdmin locale(LocaleEnum locale) {
+    this.locale = locale;
+    return this;
+  }
+
+  /**
+   * The locale of the target account's admin user..
+   * @return locale
+   **/
+  @Schema(description = "The locale of the target account's admin user.")
+  public LocaleEnum getLocale() {
+    return locale;
+  }
+
+  /**
+   * setLocale.
+   **/
+  public void setLocale(LocaleEnum locale) {
+    this.locale = locale;
+  }
+
+
+  /**
+   * Compares objects.
+   *
+   * @return true or false depending on comparison result.
+   */
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AssetGroupAccountCloneTargetAccountAdmin assetGroupAccountCloneTargetAccountAdmin = (AssetGroupAccountCloneTargetAccountAdmin) o;
+    return Objects.equals(this.email, assetGroupAccountCloneTargetAccountAdmin.email) &&
+        Objects.equals(this.firstName, assetGroupAccountCloneTargetAccountAdmin.firstName) &&
+        Objects.equals(this.lastName, assetGroupAccountCloneTargetAccountAdmin.lastName) &&
+        Objects.equals(this.locale, assetGroupAccountCloneTargetAccountAdmin.locale);
+  }
+
+  /**
+   * Returns the HashCode.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(email, firstName, lastName, locale);
+  }
+
+
+  /**
+   * Converts the given object to string.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AssetGroupAccountCloneTargetAccountAdmin {\n");
+    
+    sb.append("    email: ").append(toIndentedString(email)).append("\n");
+    sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+    sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+    sb.append("    locale: ").append(toIndentedString(locale)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/src/main/java/com/docusign/admin/model/AssetGroupAccountClones.java
+++ b/src/main/java/com/docusign/admin/model/AssetGroupAccountClones.java
@@ -1,0 +1,81 @@
+package com.docusign.admin.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.docusign.admin.model.AssetGroupAccountClone;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * AssetGroupAccountClones.
+ *
+ */
+
+public class AssetGroupAccountClones {
+  @JsonProperty("assetGroupWorks")
+  private java.util.List<AssetGroupAccountClone> assetGroupWorks = null;
+
+  /**
+   * The list of asset group accounts..
+   * @return assetGroupWorks
+   **/
+  @Schema(description = "The list of asset group accounts.")
+  public java.util.List<AssetGroupAccountClone> getAssetGroupWorks() {
+    return assetGroupWorks;
+  }
+
+
+  /**
+   * Compares objects.
+   *
+   * @return true or false depending on comparison result.
+   */
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AssetGroupAccountClones assetGroupAccountClones = (AssetGroupAccountClones) o;
+    return Objects.equals(this.assetGroupWorks, assetGroupAccountClones.assetGroupWorks);
+  }
+
+  /**
+   * Returns the HashCode.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(assetGroupWorks);
+  }
+
+
+  /**
+   * Converts the given object to string.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AssetGroupAccountClones {\n");
+    
+    sb.append("    assetGroupWorks: ").append(toIndentedString(assetGroupWorks)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/src/main/java/com/docusign/admin/model/AssetGroupAccountResponse.java
+++ b/src/main/java/com/docusign/admin/model/AssetGroupAccountResponse.java
@@ -1,0 +1,178 @@
+package com.docusign.admin.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * AssetGroupAccountResponse.
+ *
+ */
+
+public class AssetGroupAccountResponse {
+  @JsonProperty("assetGroupId")
+  private java.util.UUID assetGroupId = null;
+
+  @JsonProperty("assetGroupName")
+  private String assetGroupName = null;
+
+  @JsonProperty("accountId")
+  private java.util.UUID accountId = null;
+
+  @JsonProperty("accountName")
+  private String accountName = null;
+
+  @JsonProperty("externalAccountId")
+  private Long externalAccountId = null;
+
+  @JsonProperty("compliant")
+  private Boolean compliant = null;
+
+  @JsonProperty("siteId")
+  private Integer siteId = null;
+
+  @JsonProperty("siteName")
+  private String siteName = null;
+
+  /**
+   * The asset group id that the asset group account belongs to..
+   * @return assetGroupId
+   **/
+  @Schema(example = "00000000-0000-0000-0000-000000000000", description = "The asset group id that the asset group account belongs to.")
+  public java.util.UUID getAssetGroupId() {
+    return assetGroupId;
+  }
+
+  /**
+   * The name of asset group that the asset group account belongs to..
+   * @return assetGroupName
+   **/
+  @Schema(description = "The name of asset group that the asset group account belongs to.")
+  public String getAssetGroupName() {
+    return assetGroupName;
+  }
+
+  /**
+   * The account id of the asset group account..
+   * @return accountId
+   **/
+  @Schema(example = "00000000-0000-0000-0000-000000000000", description = "The account id of the asset group account.")
+  public java.util.UUID getAccountId() {
+    return accountId;
+  }
+
+  /**
+   * The account name of the asset group account..
+   * @return accountName
+   **/
+  @Schema(description = "The account name of the asset group account.")
+  public String getAccountName() {
+    return accountName;
+  }
+
+  /**
+   * The external account id of the asset group account..
+   * @return externalAccountId
+   **/
+  @Schema(description = "The external account id of the asset group account.")
+  public Long getExternalAccountId() {
+    return externalAccountId;
+  }
+
+  /**
+   * The compliant status for the account..
+   * @return compliant
+   **/
+  @Schema(description = "The compliant status for the account.")
+  public Boolean isCompliant() {
+    return compliant;
+  }
+
+  /**
+   * The site id of the asset group account..
+   * @return siteId
+   **/
+  @Schema(description = "The site id of the asset group account.")
+  public Integer getSiteId() {
+    return siteId;
+  }
+
+  /**
+   * The site name of the asset group account..
+   * @return siteName
+   **/
+  @Schema(description = "The site name of the asset group account.")
+  public String getSiteName() {
+    return siteName;
+  }
+
+
+  /**
+   * Compares objects.
+   *
+   * @return true or false depending on comparison result.
+   */
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AssetGroupAccountResponse assetGroupAccountResponse = (AssetGroupAccountResponse) o;
+    return Objects.equals(this.assetGroupId, assetGroupAccountResponse.assetGroupId) &&
+        Objects.equals(this.assetGroupName, assetGroupAccountResponse.assetGroupName) &&
+        Objects.equals(this.accountId, assetGroupAccountResponse.accountId) &&
+        Objects.equals(this.accountName, assetGroupAccountResponse.accountName) &&
+        Objects.equals(this.externalAccountId, assetGroupAccountResponse.externalAccountId) &&
+        Objects.equals(this.compliant, assetGroupAccountResponse.compliant) &&
+        Objects.equals(this.siteId, assetGroupAccountResponse.siteId) &&
+        Objects.equals(this.siteName, assetGroupAccountResponse.siteName);
+  }
+
+  /**
+   * Returns the HashCode.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(assetGroupId, assetGroupName, accountId, accountName, externalAccountId, compliant, siteId, siteName);
+  }
+
+
+  /**
+   * Converts the given object to string.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AssetGroupAccountResponse {\n");
+    
+    sb.append("    assetGroupId: ").append(toIndentedString(assetGroupId)).append("\n");
+    sb.append("    assetGroupName: ").append(toIndentedString(assetGroupName)).append("\n");
+    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+    sb.append("    accountName: ").append(toIndentedString(accountName)).append("\n");
+    sb.append("    externalAccountId: ").append(toIndentedString(externalAccountId)).append("\n");
+    sb.append("    compliant: ").append(toIndentedString(compliant)).append("\n");
+    sb.append("    siteId: ").append(toIndentedString(siteId)).append("\n");
+    sb.append("    siteName: ").append(toIndentedString(siteName)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/src/main/java/com/docusign/admin/model/AssetGroupAccountsResponse.java
+++ b/src/main/java/com/docusign/admin/model/AssetGroupAccountsResponse.java
@@ -1,0 +1,81 @@
+package com.docusign.admin.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.docusign.admin.model.AssetGroupAccountResponse;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * AssetGroupAccountsResponse.
+ *
+ */
+
+public class AssetGroupAccountsResponse {
+  @JsonProperty("assetGroupAccounts")
+  private java.util.List<AssetGroupAccountResponse> assetGroupAccounts = null;
+
+  /**
+   * The list of asset group accounts..
+   * @return assetGroupAccounts
+   **/
+  @Schema(description = "The list of asset group accounts.")
+  public java.util.List<AssetGroupAccountResponse> getAssetGroupAccounts() {
+    return assetGroupAccounts;
+  }
+
+
+  /**
+   * Compares objects.
+   *
+   * @return true or false depending on comparison result.
+   */
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AssetGroupAccountsResponse assetGroupAccountsResponse = (AssetGroupAccountsResponse) o;
+    return Objects.equals(this.assetGroupAccounts, assetGroupAccountsResponse.assetGroupAccounts);
+  }
+
+  /**
+   * Returns the HashCode.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(assetGroupAccounts);
+  }
+
+
+  /**
+   * Converts the given object to string.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AssetGroupAccountsResponse {\n");
+    
+    sb.append("    assetGroupAccounts: ").append(toIndentedString(assetGroupAccounts)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/src/main/java/com/docusign/admin/model/CloneErrorDetails.java
+++ b/src/main/java/com/docusign/admin/model/CloneErrorDetails.java
@@ -1,0 +1,108 @@
+package com.docusign.admin.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * CloneErrorDetails.
+ *
+ */
+
+public class CloneErrorDetails {
+  @JsonProperty("error")
+  private String error = null;
+
+  @JsonProperty("errorDescription")
+  private String errorDescription = null;
+
+  @JsonProperty("isSystemError")
+  private Boolean isSystemError = null;
+
+  /**
+   * The error code..
+   * @return error
+   **/
+  @Schema(description = "The error code.")
+  public String getError() {
+    return error;
+  }
+
+  /**
+   * The error description..
+   * @return errorDescription
+   **/
+  @Schema(description = "The error description.")
+  public String getErrorDescription() {
+    return errorDescription;
+  }
+
+  /**
+   * Whether the error is caused by the system or user..
+   * @return isSystemError
+   **/
+  @Schema(description = "Whether the error is caused by the system or user.")
+  public Boolean isIsSystemError() {
+    return isSystemError;
+  }
+
+
+  /**
+   * Compares objects.
+   *
+   * @return true or false depending on comparison result.
+   */
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CloneErrorDetails cloneErrorDetails = (CloneErrorDetails) o;
+    return Objects.equals(this.error, cloneErrorDetails.error) &&
+        Objects.equals(this.errorDescription, cloneErrorDetails.errorDescription) &&
+        Objects.equals(this.isSystemError, cloneErrorDetails.isSystemError);
+  }
+
+  /**
+   * Returns the HashCode.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(error, errorDescription, isSystemError);
+  }
+
+
+  /**
+   * Converts the given object to string.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CloneErrorDetails {\n");
+    
+    sb.append("    error: ").append(toIndentedString(error)).append("\n");
+    sb.append("    errorDescription: ").append(toIndentedString(errorDescription)).append("\n");
+    sb.append("    isSystemError: ").append(toIndentedString(isSystemError)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+


### PR DESCRIPTION
### Changed
- Added support for version v2.1-1.3.0 of the DocuSign Admin API.
- Updated the SDK release version.

New endpoints:
* `GET /v1/organizations/{organizationId}/assetGroups/accounts` Get asset group accounts for an organization.
* `POST /v1/organizations/{organizationId}/assetGroups/accountClone` Clone an existing DocuSign account.
* `GET /v1/organizations/{organizationId}/assetGroups/accountClones` Gets all asset group account clones for an organization.
* `GET /v1/organizations/{organizationId}/assetGroups/{assetGroupId}/accountClones/{assetGroupWorkId}` Gets information about a single cloned account.